### PR TITLE
Fix initialize

### DIFF
--- a/lib/statinize/statinizable.rb
+++ b/lib/statinize/statinizable.rb
@@ -6,15 +6,17 @@ module Statinize
     end
 
     module PrependedMethods
-      def initialize(*args, **kwargs)
-        self.class.statinizer.attributes.map(&:name).each do |attr|
-          instance_variable_set("@#{attr}", kwargs.delete(attr)) if kwargs.key?(attr)
+      def initialize(*args, **kwargs, &block)
+        if private_methods(false).include? :initialize
+          super(*args, **kwargs, &block)
+        else
+          self.class.statinizer.attributes.map(&:name).each do |attr|
+            instance_variable_set("@#{attr}", kwargs[attr]) if kwargs.key?(attr)
+          end
         end
 
         define_validation
         validate!
-
-        super(*args, **kwargs)
       end
 
       def validation
@@ -34,7 +36,7 @@ module Statinize
 
         statinizer.instance_eval(&block)
 
-        # statinizer.check_validators_exist!
+        statinizer.check_validators_exist!
       end
 
       def statinizer


### PR DESCRIPTION
before this pr this wouldn't work as you expect:
```ruby
class Example
  include Statinize::Statinizable

  statinize do
    attribute :name
  end

  def initialize(name:, smth:)
    @name = name
    @smth = smth
  end
end

e =  Example.new(name: name, smth: smth)
```

After this pr it will. To elaborate:

- `initialize` is still unnecessary when you include `Statinizable` into a class, it will define all the attributes you defined under `statinize` block
- yet, if you want to define your own `initialize`, you can do it. You **will** receive an error if any of the attributes defined under `statinize` are not set to an instance variable with the same name