### PR TITLE
Add attributes to an instance

### DIFF
--- a/example.rb
+++ b/example.rb
@@ -60,7 +60,7 @@ example2.valid? # => true
 begin
   AnotherExampleClass.new(first_name: "b", age: "1")
 rescue Statinize::ValidationError => e
-  puts e.message # => ValidationError: ...
+  e.message # => ValidationError: ...
 end
 
 class ExampleBlockValidation

--- a/lib/statinize/statinizable.rb
+++ b/lib/statinize/statinizable.rb
@@ -24,6 +24,12 @@ module Statinize
         @validation ||= Validation.new(statinizer, self)
       end
 
+      def attributes
+        @attributes = Hash[
+          statinizer.attributes.map { |a| [a.name, public_send(a.name)] }
+        ]
+      end
+
       alias_method :define_validation, :validation
 
       def statinizer


### PR DESCRIPTION
resolves #28

Now this works:

```ruby
class Example
  include Statinize::Statinizable

  statinize do
    attribute :name, :email
  end
end

Example.new(name: 'a', email: 'b').attributes # => {name: 'a', email: 'b'}
```