### PR TITLE
Better errors

### DIFF
--- a/lib/statinize/errors.rb
+++ b/lib/statinize/errors.rb
@@ -10,10 +10,10 @@ module Statinize
   class Errors < Array
     def to_s
       nice_errors = map do |i|
-        "#{i.keys.first.to_s.split("_").tap { |attr| attr.first.capitalize! }.join(" ")} #{i.values.first}"
-      end.join("; ")
+        ">>> #{i.keys.first.to_s.split("_").tap { |attr| attr.first.capitalize! }.join(" ")} #{i.values.first}"
+      end.join(";\n")
 
-      "ValidationError: #{nice_errors}"
+      "\nValidationError:\n#{nice_errors}"
     end
   end
 end

--- a/spec/statinize/conditional_validation_spec.rb
+++ b/spec/statinize/conditional_validation_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe "Conditional Validation" do
           it "raises an error" do
             expect { subject }.to raise_error(
               Statinize::ValidationError,
-              "ValidationError: Entity should be String, found Symbol instead"
+              "\nValidationError:\n" \
+                ">>> Entity should be String, found Symbol instead"
             )
           end
         end
@@ -44,7 +45,8 @@ RSpec.describe "Conditional Validation" do
       it { is_expected.to_not be_valid }
       it "has a proper error message" do
         expect(subject.errors.to_s).to eq(
-          "ValidationError: Name should be one of hehe"
+          "\nValidationError:\n" \
+            ">>> Name should be one of hehe"
         )
       end
     end
@@ -55,7 +57,8 @@ RSpec.describe "Conditional Validation" do
       it { is_expected.to_not be_valid }
       it "has a proper error message" do
         expect(subject.errors.to_s).to eq(
-          "ValidationError: Name should be one of hoho"
+          "\nValidationError:\n" \
+            ">>> Name should be one of hoho"
         )
       end
     end
@@ -79,7 +82,8 @@ RSpec.describe "Conditional Validation" do
         it { is_expected.to_not be_valid }
         it "has a proper error message" do
           expect(subject.errors.to_s).to eq(
-            "ValidationError: Name should be one of haha"
+            "\nValidationError:\n" \
+              ">>> Name should be one of haha"
           )
         end
       end

--- a/spec/statinize/statinize_spec.rb
+++ b/spec/statinize/statinize_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe Statinize do
         it "raises an error with proper message" do
           expect { subject }.to raise_error(
             Statinize::ValidationError,
-            "ValidationError: " \
-              "First name should be String, found Integer instead; " \
-              "Last name should be String, found Integer instead"
+            "\nValidationError:\n" \
+              ">>> First name should be String, found Integer instead;\n" \
+              ">>> Last name should be String, found Integer instead"
           )
         end
       end
@@ -65,10 +65,10 @@ RSpec.describe Statinize do
         it "raises an error with proper message" do
           expect { subject }.to raise_error(
             Statinize::ValidationError,
-            "ValidationError: " \
-              "First name should be String, found Hash instead; " \
-              "Last name should be String, found Integer instead; " \
-              "Age should be Integer, found String instead"
+            "\nValidationError:\n" \
+              ">>> First name should be String, found Hash instead;\n" \
+              ">>> Last name should be String, found Integer instead;\n" \
+              ">>> Age should be Integer, found String instead"
           )
         end
       end


### PR DESCRIPTION
Not sure that's a good thing, it's definitely more cumbersome to write tests now, but errors do seem more readable.

For comparison:

with this pr:
<img width="716" alt="image" src="https://user-images.githubusercontent.com/33145320/178148514-5829e2db-46d0-49b3-884b-2a0825cf2abd.png">

without this pr:
<img width="718" alt="image" src="https://user-images.githubusercontent.com/33145320/178148579-bbc77d62-a1de-4fb5-bfaf-089c48a3be87.png">


